### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
   - nightly
 

--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,19 @@
         }
     ],
     "require": {
-        "php": "^5.3|^7.0",
+        "php": ">=5.6",
         "ext-gmp": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.1|^5.2"
+        "phpunit/phpunit": "^5.7 || ^6.5"
     },
     "autoload": {
         "psr-4": {
-            "Thunder\\Numbase\\": "src/",
+            "Thunder\\Numbase\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Thunder\\Numbase\\Tests\\": "tests/"
         }
     }

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -5,11 +5,13 @@ use Thunder\Numbase\Converter\BaseConvertConverter;
 use Thunder\Numbase\Converter\GmpConverter;
 use Thunder\Numbase\Converter\GmpStrvalConverter;
 use Thunder\Numbase\Symbols\Base62Symbols;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
-final class ConverterTest extends \PHPUnit_Framework_TestCase
+final class ConverterTest extends TestCase
 {
     public function testGmpConverter()
     {
@@ -30,21 +32,21 @@ final class ConverterTest extends \PHPUnit_Framework_TestCase
     public function testGmpStrvalExceptionOnInvalidSourceBase()
     {
         $converter = new GmpStrvalConverter(new Base62Symbols());
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $converter->convert('10', 1, 10);
     }
 
     public function testGmpStrvalExceptionOnInvalidTargetBase()
     {
         $converter = new GmpStrvalConverter(new Base62Symbols());
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $converter->convert('10', 10, 63);
     }
 
     public function testGmpStrvalExceptionOnEmptyNumber()
     {
         $converter = new GmpStrvalConverter(new Base62Symbols());
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $converter->convert('', 10, 20);
     }
 
@@ -60,21 +62,21 @@ final class ConverterTest extends \PHPUnit_Framework_TestCase
     public function testBaseConvertExceptionOnInvalidSourceBase()
     {
         $converter = new BaseConvertConverter(new Base62Symbols());
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $converter->convert('10', 40, 10);
     }
 
     public function testBaseConvertExceptionOnInvalidTargetBase()
     {
         $converter = new BaseConvertConverter(new Base62Symbols());
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $converter->convert('10', 10, 40);
     }
 
     public function testBaseConvertExceptionOnEmptyNumber()
     {
         $converter = new BaseConvertConverter(new Base62Symbols());
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $converter->convert('', 10, 20);
     }
 }

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -5,11 +5,13 @@ use Thunder\Numbase\Formatter\ArrayFormatter;
 use Thunder\Numbase\Formatter\FallbackFormatter;
 use Thunder\Numbase\Formatter\StrictFormatter;
 use Thunder\Numbase\Symbols\Base62Symbols;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
-final class FormatterTest extends \PHPUnit_Framework_TestCase
+final class FormatterTest extends TestCase
 {
     public function testFormatters()
     {
@@ -31,7 +33,7 @@ final class FormatterTest extends \PHPUnit_Framework_TestCase
     public function testExceptionInvalidSymbolStrictFormatter()
     {
         $formatter = new StrictFormatter(new Base62Symbols());
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $formatter->format(array(100), false);
     }
 }

--- a/tests/NumbaseTest.php
+++ b/tests/NumbaseTest.php
@@ -7,11 +7,13 @@ use Thunder\Numbase\Numbase;
 use Thunder\Numbase\Symbols\ArraySymbols;
 use Thunder\Numbase\Symbols\Base62Symbols;
 use Thunder\Numbase\Symbols\StringSymbols;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
-final class NumbaseTest extends \PHPUnit_Framework_TestCase
+final class NumbaseTest extends TestCase
 {
     /**
      * @dataProvider provideNumbase
@@ -90,21 +92,21 @@ final class NumbaseTest extends \PHPUnit_Framework_TestCase
     public function testExceptionOnInvalidSourceBase()
     {
         $numbase = Numbase::createDefault();
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $numbase->convert(10, 1, 16);
     }
 
     public function testExceptionOnInvalidTargetBase()
     {
         $numbase = Numbase::createDefault();
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $numbase->convert(10, 10, -20);
     }
 
     public function testExceptionOnEmptyNumber()
     {
         $numbase = Numbase::createDefault();
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $numbase->convert('', 10, 10);
     }
 }

--- a/tests/SymbolsTest.php
+++ b/tests/SymbolsTest.php
@@ -5,11 +5,13 @@ use Thunder\Numbase\Symbols\ArraySymbols;
 use Thunder\Numbase\Symbols\Base10Symbols;
 use Thunder\Numbase\Symbols\Base62Symbols;
 use Thunder\Numbase\Symbols\StringSymbols;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
-final class SymbolsTest extends \PHPUnit_Framework_TestCase
+final class SymbolsTest extends TestCase
 {
     public function testBase62Symbols()
     {
@@ -62,14 +64,14 @@ final class SymbolsTest extends \PHPUnit_Framework_TestCase
     public function testExceptionMissingSymbol()
     {
         $symbols = new Base62Symbols();
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $symbols->getSymbol('#');
     }
 
     public function testExceptionMissingValue()
     {
         $symbols = new Base62Symbols();
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $symbols->getValue('#');
     }
 }


### PR DESCRIPTION
# Changed log
- The `php-5.3` test needs the precise dist in Travis CI build.
- To be compatible with the different PHPUnit version, using the `expectedException` annotation.
- Set the different PHPUnit version to support the multiple PHP versions.